### PR TITLE
Fix disappearing icons

### DIFF
--- a/firmware/application/apps/ui_debug.cpp
+++ b/firmware/application/apps/ui_debug.cpp
@@ -346,12 +346,12 @@ DebugPeripheralsMenuView::DebugPeripheralsMenuView(NavigationView& nav) {
 DebugMenuView::DebugMenuView(NavigationView& nav) {
 	add_items({
 		//{ "..",				ui::Color::light_grey(),&bitmap_icon_previous,	[&nav](){ nav.pop(); } },
-		{ "Memory", 		ui::Color::white(),	&bitmap_icon_soundboard,	[&nav](){ nav.push<DebugMemoryView>(); } },
+		{ "Memory", 		ui::Color::green(),	&bitmap_icon_soundboard,	[&nav](){ nav.push<DebugMemoryView>(); } },
 		//{ "Radio State",	ui::Color::white(),	nullptr,	[&nav](){ nav.push<NotImplementedView>(); } },
-		{ "SD Card",		ui::Color::white(),	&bitmap_icon_file,	[&nav](){ nav.push<SDCardDebugView>(); } },
-		{ "Peripherals",	ui::Color::white(),	&bitmap_icon_debug,	[&nav](){ nav.push<DebugPeripheralsMenuView>(); } },
-		{ "Temperature",	ui::Color::white(),	&bitmap_icon_transmit,	[&nav](){ nav.push<TemperatureView>(); } },
-		{ "Controls",		ui::Color::white(),	&bitmap_icon_utilities,	[&nav](){ nav.push<DebugControlsView>(); } },
+		{ "SD Card",		ui::Color::black(),	&bitmap_icon_file,	[&nav](){ nav.push<SDCardDebugView>(); } },
+		{ "Peripherals",	ui::Color::green(),	&bitmap_icon_debug,	[&nav](){ nav.push<DebugPeripheralsMenuView>(); } },
+		{ "Temperature",	ui::Color::green(),	&bitmap_icon_transmit,	[&nav](){ nav.push<TemperatureView>(); } },
+		{ "Controls",		ui::Color::black(),	&bitmap_icon_utilities,	[&nav](){ nav.push<DebugControlsView>(); } },
 	});
 	set_max_rows(2); // allow wider buttons
 }


### PR DESCRIPTION
Icons disappear when they are rolled over using the jog wheel and the colour is set to
ui::color::white()
Fixed by changing the colours of the icons to something other than ui::color::white()